### PR TITLE
Add Shopify blog workflow automation (Phase 1)

### DIFF
--- a/shopify_blog_workflow/.env.example
+++ b/shopify_blog_workflow/.env.example
@@ -1,0 +1,14 @@
+# Anthropic (Claude API)
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# Google Docs: credentials.json をダウンロードして同じディレクトリに置く
+# (セットアップ手順は README 参照)
+
+# ---- Phase 2: Shopify ----
+# SHOPIFY_SHOP_URL=your-shop.myshopify.com
+# SHOPIFY_ADMIN_API_TOKEN=shpat_xxxxx
+
+# ---- Phase 3: Meta (Instagram / Facebook) ----
+# META_PAGE_ACCESS_TOKEN=your_page_access_token
+# META_PAGE_ID=your_facebook_page_id
+# META_INSTAGRAM_ACCOUNT_ID=your_instagram_account_id

--- a/shopify_blog_workflow/blog_generator.py
+++ b/shopify_blog_workflow/blog_generator.py
@@ -1,0 +1,101 @@
+"""
+Claude API を使ってブログ記事ドラフトを生成する
+"""
+import json
+import os
+import anthropic
+
+
+SYSTEM_PROMPT = """あなたはShopifyブランド専門のプロブログライターです。
+提供されたWebサイト情報を分析し、SEOに最適化されたブログ記事を作成してください。
+
+【ブログの要件】
+- 読者: ブランドの潜在顧客・既存顧客
+- トーン: 親しみやすく、信頼感がある、専門的
+- 構成: 導入 → 本文（H2/H3セクション2〜4個） → まとめ → CTA
+- 文字数: 1500〜2500文字
+- SEO: 自然な形でキーワードを含める
+
+必ず以下のJSON形式のみで出力してください（```json ``` は不要）:
+{
+  "title": "キャッチーで検索されやすいタイトル",
+  "meta_description": "SEO用メタディスクリプション（120〜155文字）",
+  "content": "Markdown形式のブログ本文",
+  "tags": ["タグ1", "タグ2", "タグ3"],
+  "image_prompts": [
+    "英語の画像生成プロンプト1（DALL-E/Midjourney用）",
+    "英語の画像生成プロンプト2"
+  ],
+  "seo_keywords": ["メインキーワード", "サブキーワード1", "サブキーワード2"]
+}"""
+
+
+def generate_blog(site_data: dict, language: str = "ja") -> dict:
+    """Claude API でブログドラフトを生成する。"""
+    client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+
+    lang_note = "日本語で" if language == "ja" else "in English"
+
+    user_prompt = f"""以下のWebサイト情報を元に、{lang_note}ブログ記事を作成してください。
+
+【サイト情報】
+URL: {site_data['url']}
+ブランド名 / タイトル: {site_data['title']}
+概要: {site_data['meta_description']}
+価格情報: {', '.join(site_data['prices']) if site_data['prices'] else 'なし'}
+画像の説明: {', '.join(site_data['images'][:10]) if site_data['images'] else 'なし'}
+
+【サイトコンテンツ（抜粋）】
+{site_data['content'][:5000]}
+
+JSON形式で出力してください。"""
+
+    full_text = ""
+    print()
+
+    with client.messages.stream(
+        model="claude-opus-4-7",
+        max_tokens=4096,
+        thinking={"type": "adaptive"},
+        system=SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": user_prompt}],
+    ) as stream:
+        for text in stream.text_stream:
+            full_text += text
+            print(text, end="", flush=True)
+
+    print("\n")
+
+    return _parse_blog_json(full_text, site_data)
+
+
+def _parse_blog_json(raw: str, site_data: dict) -> dict:
+    """レスポンスからJSONを抽出してパースする。"""
+    # Markdownコードブロックを除去
+    text = raw.strip()
+    if "```json" in text:
+        text = text.split("```json", 1)[1].split("```", 1)[0].strip()
+    elif "```" in text:
+        text = text.split("```", 1)[1].split("```", 1)[0].strip()
+
+    # 先頭の { から末尾の } まで取り出す
+    start = text.find("{")
+    end = text.rfind("}") + 1
+    if start != -1 and end > start:
+        text = text[start:end]
+
+    try:
+        blog = json.loads(text)
+    except json.JSONDecodeError:
+        # フォールバック: 生テキストをcontentとして返す
+        blog = {
+            "title": site_data.get("title", "ブログ記事"),
+            "meta_description": site_data.get("meta_description", ""),
+            "content": raw,
+            "tags": [],
+            "image_prompts": [],
+            "seo_keywords": [],
+        }
+
+    blog["source_url"] = site_data["url"]
+    return blog

--- a/shopify_blog_workflow/config.py
+++ b/shopify_blog_workflow/config.py
@@ -1,0 +1,23 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+
+# Google Docs OAuth
+GOOGLE_SCOPES = [
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/drive.file",
+]
+GOOGLE_CREDENTIALS_FILE = os.path.join(os.path.dirname(__file__), "credentials.json")
+GOOGLE_TOKEN_FILE = os.path.join(os.path.dirname(__file__), "token.json")
+
+# Phase 2: Shopify
+SHOPIFY_SHOP_URL = os.getenv("SHOPIFY_SHOP_URL")
+SHOPIFY_ADMIN_API_TOKEN = os.getenv("SHOPIFY_ADMIN_API_TOKEN")
+
+# Phase 3: Meta
+META_PAGE_ACCESS_TOKEN = os.getenv("META_PAGE_ACCESS_TOKEN")
+META_PAGE_ID = os.getenv("META_PAGE_ID")
+META_INSTAGRAM_ACCOUNT_ID = os.getenv("META_INSTAGRAM_ACCOUNT_ID")

--- a/shopify_blog_workflow/google_docs_client.py
+++ b/shopify_blog_workflow/google_docs_client.py
@@ -1,0 +1,134 @@
+"""
+Google Docs API でブログドラフトを保存する
+初回実行時にブラウザでOAuth認証が必要
+"""
+import os
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+from config import GOOGLE_SCOPES, GOOGLE_CREDENTIALS_FILE, GOOGLE_TOKEN_FILE
+
+
+def _get_credentials() -> Credentials:
+    """OAuth2認証を行いCredentialsを返す。"""
+    creds = None
+
+    if os.path.exists(GOOGLE_TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(GOOGLE_TOKEN_FILE, GOOGLE_SCOPES)
+
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            if not os.path.exists(GOOGLE_CREDENTIALS_FILE):
+                raise FileNotFoundError(
+                    f"Google credentials.json が見つかりません: {GOOGLE_CREDENTIALS_FILE}\n"
+                    "セットアップ手順:\n"
+                    "1. Google Cloud Console → APIs & Services → Credentials\n"
+                    "2. 'OAuth 2.0 Client ID' を作成 (Desktop app)\n"
+                    "3. credentials.json をダウンロードして shopify_blog_workflow/ に配置"
+                )
+            flow = InstalledAppFlow.from_client_secrets_file(GOOGLE_CREDENTIALS_FILE, GOOGLE_SCOPES)
+            creds = flow.run_local_server(port=0)
+
+        with open(GOOGLE_TOKEN_FILE, "w") as f:
+            f.write(creds.to_json())
+
+    return creds
+
+
+def create_google_doc(blog: dict) -> str:
+    """ブログドラフトをGoogle Docとして作成し、URLを返す。"""
+    creds = _get_credentials()
+    docs = build("docs", "v1", credentials=creds)
+    drive = build("drive", "v3", credentials=creds)
+
+    # ドキュメント作成
+    title = blog.get("title", "ブログドラフト")
+    doc = docs.documents().create(body={"title": f"[Draft] {title}"}).execute()
+    doc_id = doc["documentId"]
+
+    # コンテンツ構築
+    content_lines = _build_doc_text(blog)
+    full_text = "\n".join(content_lines)
+
+    # テキスト挿入
+    requests = [
+        {
+            "insertText": {
+                "location": {"index": 1},
+                "text": full_text,
+            }
+        }
+    ]
+
+    # スタイル適用（タイトル: Heading1）
+    title_end = len(title) + 1  # +1 for newline
+    requests.append(
+        {
+            "updateParagraphStyle": {
+                "range": {"startIndex": 1, "endIndex": title_end},
+                "paragraphStyle": {"namedStyleType": "HEADING_1"},
+                "fields": "namedStyleType",
+            }
+        }
+    )
+
+    docs.documents().batchUpdate(
+        documentId=doc_id,
+        body={"requests": requests},
+    ).execute()
+
+    doc_url = f"https://docs.google.com/document/d/{doc_id}/edit"
+    return doc_url
+
+
+def _build_doc_text(blog: dict) -> list[str]:
+    """Google Docに挿入するテキストを構築する。"""
+    lines = []
+
+    # タイトル
+    lines.append(blog.get("title", "ブログドラフト"))
+    lines.append("")
+
+    # メタ情報セクション
+    lines.append("━" * 60)
+    lines.append("【SEO情報】")
+    lines.append(f"メタディスクリプション: {blog.get('meta_description', '')}")
+    lines.append(f"SEOキーワード: {', '.join(blog.get('seo_keywords', []))}")
+    lines.append(f"タグ: {', '.join(blog.get('tags', []))}")
+    lines.append(f"参照URL: {blog.get('source_url', '')}")
+    lines.append("━" * 60)
+    lines.append("")
+
+    # 本文
+    lines.append("【ブログ本文】")
+    lines.append("")
+    lines.append(blog.get("content", ""))
+    lines.append("")
+
+    # 画像プロンプト
+    image_prompts = blog.get("image_prompts", [])
+    if image_prompts:
+        lines.append("━" * 60)
+        lines.append("【画像生成プロンプト（DALL-E / Midjourney用）】")
+        lines.append("※ 以下のプロンプトで画像を生成し、記事に手動でアップロードしてください")
+        lines.append("")
+        for i, prompt in enumerate(image_prompts, 1):
+            lines.append(f"画像{i}: {prompt}")
+        lines.append("")
+
+    # クライアント確認用メモ
+    lines.append("━" * 60)
+    lines.append("【クライアント確認事項】")
+    lines.append("□ タイトルの承認")
+    lines.append("□ 本文の内容確認・修正")
+    lines.append("□ 画像のアップロード・配置")
+    lines.append("□ タグ・カテゴリの確認")
+    lines.append("□ 公開日時の設定")
+    lines.append("")
+    lines.append("承認後、Shopifyへの投稿とSNS配信を実行します。")
+
+    return lines

--- a/shopify_blog_workflow/main.py
+++ b/shopify_blog_workflow/main.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Shopify Blog Workflow Automation
+使い方: python main.py <URL> [オプション]
+"""
+import argparse
+import sys
+import json
+
+from website_analyzer import analyze_website
+from blog_generator import generate_blog
+from google_docs_client import create_google_doc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="WebサイトURLからShopifyブログドラフトを自動生成してGoogle Docsに保存します",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+例:
+  python main.py https://example-brand.com
+  python main.py https://example-brand.com --lang en
+  python main.py https://example-brand.com --no-docs --output blog.json
+        """,
+    )
+    parser.add_argument("url", help="分析するWebサイトのURL")
+    parser.add_argument(
+        "--lang",
+        default="ja",
+        choices=["ja", "en"],
+        help="ブログの言語 (デフォルト: ja)",
+    )
+    parser.add_argument(
+        "--no-docs",
+        action="store_true",
+        help="Google Docsへの保存をスキップ（標準出力に表示）",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="FILE",
+        help="ブログデータをJSONファイルに保存する（例: blog.json）",
+    )
+    args = parser.parse_args()
+
+    # Step 1: Webサイト分析
+    print(f"\n{'='*60}")
+    print(f"  Step 1: Webサイト分析")
+    print(f"{'='*60}")
+    print(f"URL: {args.url}")
+
+    try:
+        site_data = analyze_website(args.url)
+    except RuntimeError as e:
+        print(f"\nエラー: {e}", file=sys.stderr)
+        return 1
+
+    print(f"ブランド名: {site_data['title']}")
+    print(f"概要: {site_data['meta_description'][:80]}...")
+
+    # Step 2: ブログ生成
+    print(f"\n{'='*60}")
+    print(f"  Step 2: ブログ記事生成 (Claude claude-opus-4-7)")
+    print(f"{'='*60}")
+    print("生成中... ", end="", flush=True)
+
+    try:
+        blog = generate_blog(site_data, language=args.lang)
+    except Exception as e:
+        print(f"\nエラー: ブログ生成に失敗しました: {e}", file=sys.stderr)
+        return 1
+
+    print(f"タイトル  : {blog['title']}")
+    print(f"文字数    : {len(blog.get('content', ''))} 文字")
+    print(f"タグ      : {', '.join(blog.get('tags', []))}")
+    print(f"キーワード: {', '.join(blog.get('seo_keywords', []))}")
+
+    if blog.get("image_prompts"):
+        print(f"\n【画像生成プロンプト (DALL-E / Midjourney用)】")
+        for i, prompt in enumerate(blog["image_prompts"], 1):
+            print(f"  画像{i}: {prompt}")
+
+    # JSONファイル保存（オプション）
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(blog, f, ensure_ascii=False, indent=2)
+        print(f"\nJSONファイルを保存しました: {args.output}")
+
+    # Step 3: Google Docs保存
+    if args.no_docs:
+        print(f"\n{'='*60}")
+        print("【ブログ本文プレビュー】")
+        print(f"{'='*60}")
+        print(blog.get("content", ""))
+    else:
+        print(f"\n{'='*60}")
+        print(f"  Step 3: Google Docsへ保存")
+        print(f"{'='*60}")
+        print("Google Docsにアップロード中...")
+
+        try:
+            doc_url = create_google_doc(blog)
+        except FileNotFoundError as e:
+            print(f"\nエラー: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"\nエラー: Google Docsへの保存に失敗しました: {e}", file=sys.stderr)
+            return 1
+
+        print(f"\n✅ 完了！")
+        print(f"{'='*60}")
+        print(f"Google Docs URL:")
+        print(f"  {doc_url}")
+        print(f"{'='*60}")
+        print("\nクライアントにURLを共有して確認・承認をもらってください。")
+        print("承認後は以下のコマンドでShopify投稿ができます（Phase 2）:")
+        print("  python post_to_shopify.py <doc_url>")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shopify_blog_workflow/requirements.txt
+++ b/shopify_blog_workflow/requirements.txt
@@ -1,0 +1,7 @@
+anthropic
+requests
+beautifulsoup4
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib
+python-dotenv

--- a/shopify_blog_workflow/shopify_client.py
+++ b/shopify_blog_workflow/shopify_client.py
@@ -1,0 +1,109 @@
+"""
+Phase 2: Shopify Admin API でブログ記事を投稿する
+"""
+import requests
+import os
+from config import SHOPIFY_SHOP_URL, SHOPIFY_ADMIN_API_TOKEN
+
+
+def post_to_shopify(blog: dict, image_url: str | None = None) -> str:
+    """
+    承認済みブログをShopifyに投稿し、記事URLを返す。
+
+    事前準備:
+    1. Shopify Admin → Settings → Apps and sales channels → Develop apps
+    2. Custom app を作成し 'write_content' スコープを付与
+    3. Admin API access token を取得して .env に設定
+    """
+    if not SHOPIFY_SHOP_URL or not SHOPIFY_ADMIN_API_TOKEN:
+        raise EnvironmentError(
+            "SHOPIFY_SHOP_URL と SHOPIFY_ADMIN_API_TOKEN を .env に設定してください"
+        )
+
+    # Shopify デフォルトブログのIDを取得
+    blog_id = _get_default_blog_id()
+
+    # Markdown → HTML 変換（簡易）
+    html_content = _markdown_to_html(blog.get("content", ""))
+
+    # 記事データ
+    article_data = {
+        "article": {
+            "title": blog.get("title", ""),
+            "body_html": html_content,
+            "summary_html": blog.get("meta_description", ""),
+            "tags": ", ".join(blog.get("tags", [])),
+            "published": False,  # 下書きとして保存
+        }
+    }
+
+    if image_url:
+        article_data["article"]["image"] = {"src": image_url}
+
+    url = f"https://{SHOPIFY_SHOP_URL}/admin/api/2024-01/blogs/{blog_id}/articles.json"
+    headers = {
+        "X-Shopify-Access-Token": SHOPIFY_ADMIN_API_TOKEN,
+        "Content-Type": "application/json",
+    }
+
+    response = requests.post(url, json=article_data, headers=headers)
+    response.raise_for_status()
+
+    article = response.json()["article"]
+    handle = article.get("handle", "")
+    return f"https://{SHOPIFY_SHOP_URL}/blogs/news/{handle}"
+
+
+def _get_default_blog_id() -> str:
+    """ストアの最初のブログIDを取得する。"""
+    url = f"https://{SHOPIFY_SHOP_URL}/admin/api/2024-01/blogs.json"
+    headers = {"X-Shopify-Access-Token": SHOPIFY_ADMIN_API_TOKEN}
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    blogs = response.json().get("blogs", [])
+    if not blogs:
+        raise RuntimeError("Shopifyにブログが見つかりません。管理画面でブログを作成してください。")
+    return str(blogs[0]["id"])
+
+
+def _markdown_to_html(markdown: str) -> str:
+    """Markdownを簡易的にHTMLに変換する。"""
+    lines = markdown.split("\n")
+    html_lines = []
+    in_list = False
+
+    for line in lines:
+        if line.startswith("## "):
+            if in_list:
+                html_lines.append("</ul>")
+                in_list = False
+            html_lines.append(f"<h2>{line[3:].strip()}</h2>")
+        elif line.startswith("### "):
+            if in_list:
+                html_lines.append("</ul>")
+                in_list = False
+            html_lines.append(f"<h3>{line[4:].strip()}</h3>")
+        elif line.startswith("- ") or line.startswith("* "):
+            if not in_list:
+                html_lines.append("<ul>")
+                in_list = True
+            html_lines.append(f"<li>{line[2:].strip()}</li>")
+        elif line.strip() == "":
+            if in_list:
+                html_lines.append("</ul>")
+                in_list = False
+            html_lines.append("")
+        else:
+            if in_list:
+                html_lines.append("</ul>")
+                in_list = False
+            # **bold** 変換
+            text = line
+            while "**" in text:
+                text = text.replace("**", "<strong>", 1).replace("**", "</strong>", 1)
+            html_lines.append(f"<p>{text}</p>")
+
+    if in_list:
+        html_lines.append("</ul>")
+
+    return "\n".join(html_lines)

--- a/shopify_blog_workflow/social_poster.py
+++ b/shopify_blog_workflow/social_poster.py
@@ -1,0 +1,118 @@
+"""
+Phase 3: Meta Graph API で Instagram / Facebook に投稿する
+"""
+import requests
+import anthropic
+import os
+from config import META_PAGE_ACCESS_TOKEN, META_PAGE_ID, META_INSTAGRAM_ACCOUNT_ID
+
+
+def post_to_social(blog: dict, image_url: str, shopify_article_url: str) -> dict:
+    """
+    ブログ記事をSNSに投稿する。
+
+    事前準備:
+    1. Meta for Developers → My Apps → Graph API
+    2. Facebook Page Access Token を取得（publish_pages, instagram_basic, instagram_content_publish）
+    3. .env に META_PAGE_ACCESS_TOKEN, META_PAGE_ID, META_INSTAGRAM_ACCOUNT_ID を設定
+    必要な権限:
+    - pages_manage_posts
+    - instagram_content_publish
+    """
+    if not META_PAGE_ACCESS_TOKEN:
+        raise EnvironmentError("META_PAGE_ACCESS_TOKEN を .env に設定してください")
+
+    # SNS用キャプション生成
+    fb_caption, ig_caption = _generate_captions(blog, shopify_article_url)
+
+    results = {}
+
+    # Facebook投稿
+    if META_PAGE_ID:
+        fb_result = _post_to_facebook(fb_caption, image_url)
+        results["facebook"] = fb_result
+        print(f"Facebook投稿完了: {fb_result.get('id')}")
+
+    # Instagram投稿
+    if META_INSTAGRAM_ACCOUNT_ID and image_url:
+        ig_result = _post_to_instagram(ig_caption, image_url)
+        results["instagram"] = ig_result
+        print(f"Instagram投稿完了: {ig_result.get('id')}")
+
+    return results
+
+
+def _generate_captions(blog: dict, article_url: str) -> tuple[str, str]:
+    """Claude APIでSNS用キャプションを生成する。"""
+    client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+
+    response = client.messages.create(
+        model="claude-opus-4-7",
+        max_tokens=1024,
+        messages=[
+            {
+                "role": "user",
+                "content": f"""以下のブログ記事をSNSで宣伝するキャプションを作成してください。
+
+タイトル: {blog.get('title')}
+概要: {blog.get('meta_description')}
+タグ: {', '.join(blog.get('tags', []))}
+記事URL: {article_url}
+
+JSON形式で出力:
+{{
+  "facebook": "Facebookキャプション（300文字以内、URLと絵文字含む）",
+  "instagram": "Instagramキャプション（ハッシュタグ10個以上含む、改行あり）"
+}}""",
+            }
+        ],
+    )
+
+    import json
+    text = response.content[0].text.strip()
+    if "```json" in text:
+        text = text.split("```json")[1].split("```")[0].strip()
+    elif "```" in text:
+        text = text.split("```")[1].split("```")[0].strip()
+
+    data = json.loads(text)
+    return data.get("facebook", ""), data.get("instagram", "")
+
+
+def _post_to_facebook(caption: str, image_url: str | None) -> dict:
+    """Facebookページに投稿する。"""
+    url = f"https://graph.facebook.com/v18.0/{META_PAGE_ID}/feed"
+    payload = {
+        "message": caption,
+        "access_token": META_PAGE_ACCESS_TOKEN,
+    }
+    if image_url:
+        # 画像付き投稿
+        url = f"https://graph.facebook.com/v18.0/{META_PAGE_ID}/photos"
+        payload["url"] = image_url
+
+    response = requests.post(url, data=payload)
+    response.raise_for_status()
+    return response.json()
+
+
+def _post_to_instagram(caption: str, image_url: str) -> dict:
+    """Instagramに画像投稿する（2ステップ: メディア作成 → 公開）。"""
+    # Step 1: メディアコンテナ作成
+    container_url = f"https://graph.facebook.com/v18.0/{META_INSTAGRAM_ACCOUNT_ID}/media"
+    container_resp = requests.post(container_url, data={
+        "image_url": image_url,
+        "caption": caption,
+        "access_token": META_PAGE_ACCESS_TOKEN,
+    })
+    container_resp.raise_for_status()
+    container_id = container_resp.json()["id"]
+
+    # Step 2: 公開
+    publish_url = f"https://graph.facebook.com/v18.0/{META_INSTAGRAM_ACCOUNT_ID}/media_publish"
+    publish_resp = requests.post(publish_url, data={
+        "creation_id": container_id,
+        "access_token": META_PAGE_ACCESS_TOKEN,
+    })
+    publish_resp.raise_for_status()
+    return publish_resp.json()

--- a/shopify_blog_workflow/website_analyzer.py
+++ b/shopify_blog_workflow/website_analyzer.py
@@ -1,0 +1,79 @@
+"""
+Webサイトをスクレイピングしてブログ生成に必要な情報を抽出する
+"""
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urlparse
+
+
+def analyze_website(url: str) -> dict:
+    """URLをスクレイピングしてサイト情報を返す。"""
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        )
+    }
+
+    try:
+        response = requests.get(url, headers=headers, timeout=20)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise RuntimeError(f"URLの取得に失敗しました ({url}): {e}")
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    # ノイズ除去
+    for tag in soup(["script", "style", "nav", "footer", "header", "aside", "iframe", "noscript"]):
+        tag.decompose()
+
+    # タイトル
+    title = soup.title.string.strip() if soup.title else ""
+
+    # メタディスクリプション
+    meta_desc = ""
+    meta_tag = soup.find("meta", attrs={"name": "description"})
+    if meta_tag:
+        meta_desc = meta_tag.get("content", "").strip()
+
+    # OGP情報
+    og_title = ""
+    og_desc = ""
+    og_tag = soup.find("meta", property="og:title")
+    if og_tag:
+        og_title = og_tag.get("content", "").strip()
+    og_desc_tag = soup.find("meta", property="og:description")
+    if og_desc_tag:
+        og_desc = og_desc_tag.get("content", "").strip()
+
+    # メインコンテンツ抽出
+    main = (
+        soup.find("main")
+        or soup.find("article")
+        or soup.find(class_=lambda c: c and any(k in str(c) for k in ["content", "main", "product"]))
+        or soup.find("body")
+    )
+    raw_text = main.get_text(separator=" ", strip=True) if main else ""
+    # 連続スペース・改行を正規化
+    content = " ".join(raw_text.split())
+
+    # 長すぎる場合は先頭8000字
+    if len(content) > 8000:
+        content = content[:8000] + "..."
+
+    # 画像のalt属性（商品名ヒント）
+    images = [img.get("alt", "").strip() for img in soup.find_all("img", alt=True)]
+    images = [alt for alt in images if len(alt) > 3][:20]
+
+    # 商品・価格情報の断片
+    prices = [tag.get_text(strip=True) for tag in soup.find_all(class_=lambda c: c and "price" in str(c).lower())][:10]
+
+    return {
+        "url": url,
+        "domain": urlparse(url).netloc,
+        "title": og_title or title,
+        "meta_description": og_desc or meta_desc,
+        "content": content,
+        "images": images,
+        "prices": prices,
+    }


### PR DESCRIPTION
- website_analyzer.py: Scrape and extract brand/product content from any URL
- blog_generator.py: Generate SEO-optimized blog drafts via Claude Opus 4.7 (streaming)
- google_docs_client.py: Save draft to Google Docs with client review checklist
- shopify_client.py: Post approved blog to Shopify Admin API (Phase 2)
- social_poster.py: Auto-post to Instagram/Facebook via Meta Graph API (Phase 3)
- main.py: CLI orchestration with --lang, --no-docs, --output flags

Usage: python main.py <URL> [--lang ja|en] [--no-docs]

https://claude.ai/code/session_01XLzaT3ytkZtwZraTySnPNB